### PR TITLE
Fix data loading issues

### DIFF
--- a/positions-injector/src/main/java/workshop/positions/PositionsInjector.java
+++ b/positions-injector/src/main/java/workshop/positions/PositionsInjector.java
@@ -1,6 +1,7 @@
 package workshop.positions;
 
 import hu.akarnokd.rxjava2.interop.CompletableInterop;
+import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.reactivex.Single;
 import io.reactivex.schedulers.Schedulers;
@@ -87,8 +88,8 @@ public class PositionsInjector extends AbstractVerticle {
 
         rxReadGunzippedTextResource("cff_train_position-2016-02-29__.jsonl.gz")
           .map(PositionsInjector::toEntry)
-          .flatMapCompletable(e -> CompletableInterop.fromFuture(positions.putAsync(e.getKey(), e.getValue())))
-          .subscribeOn(Schedulers.io())
+          .map(e -> CompletableInterop.fromFuture(positions.putAsync(e.getKey(), e.getValue())))
+          .to(flowable -> Completable.merge(flowable, 100))
           .subscribe(() -> {}, t -> log.log(SEVERE, "Error while loading", t));
 
         ctx.response().end("Injector started");

--- a/stations-injector/src/main/java/workshop/stations/StationsInjector.java
+++ b/stations-injector/src/main/java/workshop/stations/StationsInjector.java
@@ -1,6 +1,7 @@
 package workshop.stations;
 
 import hu.akarnokd.rxjava2.interop.CompletableInterop;
+import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.reactivex.Single;
 import io.reactivex.schedulers.Schedulers;
@@ -32,6 +33,7 @@ import java.util.AbstractMap;
 import java.util.Date;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.zip.GZIPInputStream;
@@ -91,10 +93,13 @@ public class StationsInjector extends AbstractVerticle {
         // TODO 1: map each entry of the Flowable into a tuple of String/Stop with StationsInjector::toEntry
         Flowable<Map.Entry<String, Stop>> pairFlowable = null;
 
-        // TODO 2. for each entry, store it in the stations cache calling putAsync
-        Flowable<?> putFlowable = null;
+        Completable putCompletable = pairFlowable.flatMapCompletable(e -> {
+          // TODO 2. store each entry in the stations cache calling putAsync
+          CompletableFuture<Stop> putCompletableFuture = null;
+          return CompletableInterop.fromFuture(putCompletableFuture);
+        });
 
-        putFlowable.subscribe(v -> {}, t -> log.log(SEVERE, "Error while loading", t));
+        putCompletable.subscribe(() -> {}, t -> log.log(SEVERE, "Error while loading", t));
 
         ctx.response().end("Injector started");
       });

--- a/stations-injector/src/main/java/workshop/stations/StationsInjector.java
+++ b/stations-injector/src/main/java/workshop/stations/StationsInjector.java
@@ -93,13 +93,13 @@ public class StationsInjector extends AbstractVerticle {
         // TODO 1: map each entry of the Flowable into a tuple of String/Stop with StationsInjector::toEntry
         Flowable<Map.Entry<String, Stop>> pairFlowable = null;
 
-        Completable putCompletable = pairFlowable.flatMapCompletable(e -> {
+        Completable completable = pairFlowable.map(e -> {
           // TODO 2. store each entry in the stations cache calling putAsync
           CompletableFuture<Stop> putCompletableFuture = null;
           return CompletableInterop.fromFuture(putCompletableFuture);
-        });
+        }).to(flowable -> Completable.merge(flowable, 100));
 
-        putCompletable.subscribe(() -> {}, t -> log.log(SEVERE, "Error while loading", t));
+        completable.subscribe(() -> {}, t -> log.log(SEVERE, "Error while loading", t));
 
         ctx.response().end("Injector started");
       });

--- a/workshop-steps/workshop.html
+++ b/workshop-steps/workshop.html
@@ -610,28 +610,27 @@ datagrid-1-zf16b
         <pre>
           <code class="java">private void inject(RoutingContext ctx) {
     vertx
-      .&lt;RemoteCache&lt;String, Stop&gt;&gt;rxExecuteBlocking(fut -> fut.complete(client.getCache(STATION_BOARDS_CACHE_NAME)))
+      .&lt;RemoteCache&lt;String, Stop&gt;&gt;rxExecuteBlocking(fut -&gt; fut.complete(client.getCache(STATION_BOARDS_CACHE_NAME)))
       // Remove data on start, to start clean
-      .flatMap(stations -> CompletableInterop.fromFuture(stations.clearAsync()).andThen(Single.just(stations)))
+      .flatMap(stations -&gt; CompletableInterop.fromFuture(stations.clearAsync()).andThen(Single.just(stations)))
       .subscribeOn(RxHelper.scheduler(vertx.getOrCreateContext()))
-      .subscribe(stations -> {
-        vertx.setPeriodic(5000L, l ->
-          vertx.executeBlocking(fut -> {
+      .subscribe(stations -&gt; {
+        vertx.setPeriodic(5000L, l -&gt;
+          vertx.executeBlocking(fut -&gt; {
             log.info(String.format("Progress: stored=%d%n", stations.size()));
             fut.complete();
-          }, false, ar -> {}));
+          }, false, ar -&gt; {}));
 
         Flowable&lt;String&gt; fileFlowable = rxReadGunzippedTextResource("cff-stop-2016-02-29__.jsonl.gz");
 
-        Flowable&lt;Map.Entry&lt;String, Stop&gt;&gt; pairFlowable =
-          fileFlowable.map(StationsInjector::toEntry);
+        Flowable&lt;Map.Entry&lt;String, Stop&gt;&gt; pairFlowable = fileFlowable.map(StationsInjector::toEntry);
 
-        Completable putCompletable = pairFlowable.flatMapCompletable(e -> {
+        Completable completable = pairFlowable.map(e -&gt; {
           CompletableFuture&lt;Stop&gt; putCompletableFuture = stations.putAsync(e.getKey(), e.getValue());
           return CompletableInterop.fromFuture(putCompletableFuture);
-        });
+        }).to(flowable -&gt; Completable.merge(flowable, 100));
 
-        putCompletable.subscribe(() -> {}, t -> log.log(SEVERE, "Error while loading", t));
+        completable.subscribe(() -&gt; {}, t -&gt; log.log(SEVERE, "Error while loading", t));
 
         ctx.response().end("Injector started");
       });

--- a/workshop-steps/workshop.html
+++ b/workshop-steps/workshop.html
@@ -594,7 +594,7 @@ datagrid-1-zf16b
           <li><kbd>TODO 2</kbd> For each entry, store it in the stations cache calling <code>putAsync</code>
             <br/><a class="btn btn-info" role="button" onclick="$('#array-sol-14').toggle();">Show/Hide Solution</a>
             <div id="array-sol-14" style="display:none;">
-              <pre><code class="java">Flowable&lt;?&gt; putFlowable = pairFlowable.doOnNext(e -> stations.putAsync(e.getKey(), e.getValue()));</code></pre></div>
+              <pre><code class="java">CompletableFuture&lt;Stop&gt; putCompletableFuture = stations.putAsync(e.getKey(), e.getValue());</code></pre></div>
           </li>
         </ul>
 
@@ -626,10 +626,12 @@ datagrid-1-zf16b
         Flowable&lt;Map.Entry&lt;String, Stop&gt;&gt; pairFlowable =
           fileFlowable.map(StationsInjector::toEntry);
 
-        Flowable&lt;?&gt; putFlowable =
-          pairFlowable.doOnNext(e -> stations.putAsync(e.getKey(), e.getValue()));
+        Completable putCompletable = pairFlowable.flatMapCompletable(e -> {
+          CompletableFuture&lt;Stop&gt; putCompletableFuture = stations.putAsync(e.getKey(), e.getValue());
+          return CompletableInterop.fromFuture(putCompletableFuture);
+        });
 
-        putFlowable.subscribe(v -> {}, t -> log.log(SEVERE, "Error while loading", t));
+        putCompletable.subscribe(() -> {}, t -> log.log(SEVERE, "Error while loading", t));
 
         ctx.response().end("Injector started");
       });


### PR DESCRIPTION
One process was still using doOnNext, so ignoring the completion of the operation.

Also, previous implementations of StationsInjector and PositionsInjector were often interrupted by a RejectedOperationException.
This was due to the queue of the ISPN client asyncExecutor being full.
The new implementation makes sure no more than 100 puts can be scheduled at once.
  